### PR TITLE
Add web3 as an `any` (for now) declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,8 @@ declare function contract(name: string, test: (accounts: Truffle.Accounts) => vo
 
 declare const artifacts: Truffle.Artifacts;
 
+declare const web3: any;
+
 /**
  * Namespace
  */


### PR DESCRIPTION
#1 Also states that there are other missing typings which could be added into here. I was wondering if there was a reason you haven't included these yet? I could assume maybe you left out `web3` since there's no good type system for that yet. I was patching it locally by declaring type `any` so figure we could bring that upstream since `web3` is a provided by Truffle and used pretty often