### PR TITLE
Declare BN and Web3 types and use them

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,14 +3,18 @@
  */
 /// <reference types="chai" />
 /// <reference types="mocha" />
+
+declare type BN = import("bn.js");
+declare type Web3 = import("web3");
+
 declare const assert: Chai.AssertStatic;
 declare const expect: Chai.ExpectStatic;
+
+declare const web3: Web3;
 
 declare function contract(name: string, test: (accounts: Truffle.Accounts) => void): void;
 
 declare const artifacts: Truffle.Artifacts;
-
-declare const web3: any;
 
 /**
  * Namespace
@@ -19,10 +23,10 @@ declare namespace Truffle {
   type Accounts = string[];
 
   interface TransactionDetails {
-    from: string;
-    gas?: number | string;
-    gasPrice?: number | string;
-    value?: number | string;
+    from?: string;
+    gas?: BN | number | string;
+    gasPrice?: BN | number | string;
+    value?: BN | string;
   }
 
   export interface TransactionLog {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "license": "MIT",
   "dependencies": {
     "@types/chai": "^4.1.4",
-    "@types/mocha": "^5.2.5"
+    "@types/mocha": "^5.2.5",
+    "@types/web3": "^1.0.18"
   },
   "types": "./index.d.ts"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@types/bn.js@*":
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.4.tgz#a7bed5bdef9f16b25c92ba27745ab261374787d7"
+  integrity sha512-AO8WW+aRcKWKQAYTfKLzwnpL6U+TfPqS+haRrhCy5ff04Da8WZud3ZgVjspQXaEXJDcTlsjUEVvL39wegDek5w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/chai@^4.1.4":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.4.tgz#5ca073b330d90b4066d6ce18f60d57f2084ce8ca"
@@ -11,3 +18,21 @@
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
   integrity sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==
+
+"@types/node@*":
+  version "10.12.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.21.tgz#7e8a0c34cf29f4e17a36e9bd0ea72d45ba03908e"
+  integrity sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==
+
+"@types/underscore@*":
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.8.9.tgz#fef41f800cd23db1b4f262ddefe49cd952d82323"
+  integrity sha512-vfzZGgZKRFy7KEWcBGfIFk+h6B+thDCLfkD1exMBMRlUsx2icA+J6y4kAbZs/TjSTeY1duw89QUU133TSzr60Q==
+
+"@types/web3@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@types/web3/-/web3-1.0.18.tgz#87a8651041d21fc37602ff02327df2c7ecf105d1"
+  integrity sha512-uXQL0LDszt2f476LEmYM6AvSv9F4vU4hWQvlUhwfLHNlIB6OyBXoYsCzWAIhhnc5U0HA7ZBcPybxRJ/yfA6THg==
+  dependencies:
+    "@types/bn.js" "*"
+    "@types/underscore" "*"


### PR DESCRIPTION
We can use typescript's `import()` to declare external types, which I apply to `BN` from `bn.js` and `Web3` from `web3`.

While `@types/web3` is certainly not perfect, it is better than not having any types at all and they work reasonably well (for me). It can always be overwritten with `declare const web3: any` by the user, I think.

I also changed the `TransactionDetails` to have `from` as an optional and the other fields to be `BN`s. Note in particular that web3's `value` doesn't accept a `number` any more. To convert strings and numbers to a `BN`, use `web3.utils.toBN()`.

It is also possible to use the `web3` node module directly. However, then the two declarations have to be changed to:
```typescript
declare type BN = import("web3-utils").BN;
declare type Web3 = import("web3").default;
```
There is also currently a bug in `web3.js`'s types, making it impossible to compile `web3-utils`, because it doesn't correctly import/require `bn.js`. [It will be fixed this week.](https://github.com/ethereum/web3.js/issues/2290)

Also relates to https://github.com/ethereum-ts/TypeChain/issues/136
