### PR TITLE
Add missing Web3.Contract property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,7 @@ declare namespace Truffle {
 
   interface ContractInstance {
     address: string;
+    contract: any;
     transactionHash: string;
   }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ethereum",
     "smartcontract"
   ],
-  "version": "1.0.5",
+  "version": "1.1.0",
   "repository": "git@github.com:ethereum-ts/truffle-typings.git",
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "license": "MIT",


### PR DESCRIPTION
As per truffle version 5.0.0 and above, there's an additional `Web3.Contract` type in `Truffle.ContractInstance`. All I did was to add a new `contract: any`, but I guess it might be worth it to take a look at these [web3 typings from 0x](web3-typings).

[web3-typings]: https://github.com/0xProject/0x-monorepo/blob/development/packages/typescript-typings/types/web3/index.d.ts