### PR TITLE
Allow contract.skip and contract.only in tests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,9 +12,26 @@ declare const expect: Chai.ExpectStatic;
 
 declare const web3: Web3;
 
-declare function contract(name: string, test: (accounts: Truffle.Accounts) => void): void;
-
 declare const artifacts: Truffle.Artifacts;
+
+/**
+ * Global contract function
+ */
+interface ContractFunction extends Mocha.SuiteFunction {
+  (title: string, fn: (this: Mocha.Suite, accounts: Truffle.Accounts) => void): Mocha.Suite;
+  only: ExclusiveContractFunction;
+  skip: PendingContractFunction;
+}
+
+interface ExclusiveContractFunction extends Mocha.ExclusiveSuiteFunction {
+  (title: string, fn: (this: Mocha.Suite, accounts: Truffle.Accounts) => void): Mocha.Suite;
+}
+
+interface PendingContractFunction extends Mocha.PendingSuiteFunction {
+  (title: string, fn: (this: Mocha.Suite, accounts: Truffle.Accounts) => void): Mocha.Suite | void;
+}
+
+declare const contract: ContractFunction;
 
 /**
  * Namespace


### PR DESCRIPTION
This PR uses Mocha's `Suite` type for `contract` so it has the properties `.skip` and `.only`:

```js
contract.skip("Greeter", ([deployer, user1]) => {
    ...
});
```

and

```js
contract.only("Greeter", ([deployer, user1]) => {
    ...
});
```