### PR TITLE
Makes `Contract<T>.at(...)` return a `Promise<T>` instead of `T`.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare namespace Truffle {
 
   interface Contract<T> extends ContractNew<any[]> {
     deployed(): Promise<T>;
-    at(address: string): T;
+    at(address: string): Promise<T>;
     address: string;
     contractName: string;
   }


### PR DESCRIPTION
At least in Truffle 5.0.x, this function returns a promise.